### PR TITLE
Support async conversion result reuse and optional method appending

### DIFF
--- a/RoslynRunner.Utilities.InvocationTrees/AsyncConversion/AsyncConversionProcessorParameters.cs
+++ b/RoslynRunner.Utilities.InvocationTrees/AsyncConversion/AsyncConversionProcessorParameters.cs
@@ -1,3 +1,3 @@
 namespace RoslynRunner.Utilities.InvocationTrees;
 
-public record AsyncConversionParameters(string OutputPath, string TypeName, string? MethodName = null);
+public record AsyncConversionParameters(string OutputPath, string TypeName, string? MethodName = null, bool ReplaceExistingMethods = true);

--- a/RoslynRunner.Utilities.InvocationTrees/AsyncConversion/AsyncConversionResult.cs
+++ b/RoslynRunner.Utilities.InvocationTrees/AsyncConversion/AsyncConversionResult.cs
@@ -1,0 +1,17 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace RoslynRunner.Utilities.InvocationTrees;
+
+/// <summary>
+/// Represents the results of running the async conversion engine.
+/// </summary>
+public sealed record AsyncConversionResult(
+    CompilationUnitSyntax OriginalRoot,
+    CompilationUnitSyntax UpdatedRoot,
+    ImmutableArray<AsyncMethodConversion> ConvertedMethods,
+    InvocationTreeResult InvocationTree);
+
+public sealed record AsyncMethodConversion(
+    MethodDeclarationSyntax OriginalMethod,
+    MethodDeclarationSyntax AsyncMethod);

--- a/RoslynRunner.Utilities.InvocationTrees/InvocationTreeProcessor.cs
+++ b/RoslynRunner.Utilities.InvocationTrees/InvocationTreeProcessor.cs
@@ -24,12 +24,11 @@ public class InvocationTreeProcessor : ISolutionProcessor<InvocationTreeProcesso
         var symbol = await FindSymbol(solution, parameters.StartingSymbol,
             cancellationToken);
 
-        InvocationRoot? results = null;
-        List<InvocationMethod> allMethods = new();
+        InvocationTreeResult invocationTreeResult;
         if (parameters.UseCache)
         {
             var cache = await CachedSymbolFinder.FromCache(solution);
-            (results, allMethods) = await InvocationTreeBuilder.BuildInvocationTreeWithCacheAsync(
+            invocationTreeResult = await InvocationTreeBuilder.BuildInvocationTreeWithCacheAsync(
                 cachedSymbolFinder: cache,
                 startingType: (INamedTypeSymbol)symbol!,
                 solution: solution,
@@ -39,7 +38,7 @@ public class InvocationTreeProcessor : ISolutionProcessor<InvocationTreeProcesso
         }
         else
         {
-            (results, allMethods) =
+            invocationTreeResult =
                 await InvocationTreeBuilder.BuildInvocationTreeAsync(
                     startingType: (INamedTypeSymbol)symbol!,
                     solution: solution,
@@ -48,6 +47,8 @@ public class InvocationTreeProcessor : ISolutionProcessor<InvocationTreeProcesso
                     cancellationToken: cancellationToken);
 
         }
+        var results = invocationTreeResult.Root;
+        var allMethods = invocationTreeResult.AllMethods.ToList();
         var runContext = RunContextAccessor.RunContext;
 
         if (parameters.Diagrams != null)

--- a/RoslynRunner.Utilities.InvocationTrees/InvocationTreeResult.cs
+++ b/RoslynRunner.Utilities.InvocationTrees/InvocationTreeResult.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace RoslynRunner.Utilities.InvocationTrees;
+
+/// <summary>
+/// Represents the result of crawling the invocation tree for a symbol.
+/// </summary>
+public sealed record InvocationTreeResult(InvocationRoot Root, ImmutableArray<InvocationMethod> AllMethods)
+{
+    public static InvocationTreeResult Empty { get; } =
+        new(new InvocationRoot(new List<InvocationMethod>()), ImmutableArray<InvocationMethod>.Empty);
+}

--- a/samples/LegacyWebApp/LegacyWebAppConverter/ConvertToMinimalApi.cs
+++ b/samples/LegacyWebApp/LegacyWebAppConverter/ConvertToMinimalApi.cs
@@ -74,10 +74,10 @@ public class ConvertToMinimalApi : ISolutionProcessor<ConvertToMinimalApiContext
             if (serviceType != null)
             {
                 var engine = new AsyncConversionEngine(cache, solution);
-                var newRoot = await engine.GenerateAsyncVersion(serviceType, context.AsyncMethodName, cancellationToken);
-                if (newRoot != null)
+                var conversionResult = await engine.GenerateAsyncVersion(serviceType, context.AsyncMethodName, cancellationToken);
+                if (conversionResult != null)
                 {
-                    await File.WriteAllTextAsync(context.AsyncOutputPath, newRoot.ToFullString(), cancellationToken);
+                    await File.WriteAllTextAsync(context.AsyncOutputPath, conversionResult.UpdatedRoot.ToFullString(), cancellationToken);
                     RunContextAccessor.RunContext.Output.Add($"Created file: {Path.GetFullPath(context.AsyncOutputPath)}");
                 }
             }


### PR DESCRIPTION
## Summary
- add `InvocationTreeResult` and `AsyncConversionResult` types so callers can reuse invocation tree crawls and inspect converted methods
- update the async conversion engine and processor to work with the encapsulated results and optionally append async methods instead of replacing the originals
- expand the async conversion unit tests and sample converter to cover the new behaviors

## Testing
- dotnet test Tests/RoslynRunner.AsyncConversion.UnitTests/RoslynRunner.AsyncConversion.UnitTests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68ee6fd168f0832f811e39f19b2b8036