### PR TITLE
Fix async conversion pipeline failures

### DIFF
--- a/RoslynRunner.Core/CompilationTools.cs
+++ b/RoslynRunner.Core/CompilationTools.cs
@@ -54,7 +54,16 @@ public static class CompilationTools
 
         if (!result.Success)
         {
-            return null;
+            var diagnostics = result.Diagnostics
+                .Where(d => d.Severity == DiagnosticSeverity.Error)
+                .Select(d => $"{d.Id}: {d.GetMessage()}")
+                .ToArray();
+
+            var message = diagnostics.Length == 0
+                ? "Unknown compilation error while emitting in-memory assembly."
+                : $"Compilation failed with {diagnostics.Length} error(s): {string.Join("; ", diagnostics)}";
+
+            throw new InvalidOperationException(message);
         }
 
         assemblyStream.Seek(0, SeekOrigin.Begin);

--- a/Tests/RoslynRunner.AsyncConversion.UnitTests/AsyncConversionProcessorTests.cs
+++ b/Tests/RoslynRunner.AsyncConversion.UnitTests/AsyncConversionProcessorTests.cs
@@ -192,6 +192,9 @@ public class AsyncConversionProcessorTests
             "Sample.RecursiveService",
             ReplaceExistingMethods: false);
 
+        var runContext = new RunContext(Guid.NewGuid());
+        RunContextAccessor.RunContext = runContext;
+
         try
         {
             await processor.ProcessSolution(solution, parameters, NullLogger.Instance, CancellationToken.None);
@@ -221,6 +224,8 @@ public class AsyncConversionProcessorTests
         }
         finally
         {
+            RunContextAccessor.Clear();
+
             if (Directory.Exists(outputDirectory))
             {
                 Directory.Delete(outputDirectory, recursive: true);

--- a/samples/LegacyWebApp/LegacyWebApp/LegacyWebApp/LegacyWebApp.csproj
+++ b/samples/LegacyWebApp/LegacyWebApp/LegacyWebApp/LegacyWebApp.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.3.0" />
         <PackageReference Include="Microsoft.AspNet.WebApi.SelfHost" Version="5.3.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" PrivateAssets="all" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
## Summary
- ensure the API test harness restores the legacy sample solution before exercising conversions and add the missing reference assembly package
- improve async conversion handling by relaxing parameter matching, only passing cancellation tokens when supported, and surfacing emit errors
- update unit tests to create a run context for append scenarios so the processor can record output

## Testing
- dotnet test --logger "console;verbosity=normal"

------
https://chatgpt.com/codex/tasks/task_e_68ee7659eb1c832fa330dfa38034f138