### PR TITLE
Gate Playwright tests behind opt-in flag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,8 +31,8 @@ jobs:
       - name: Build the legacy sample
         run: dotnet build
         working-directory: samples/LegacyWebApp
-      - name: Run API tests
-        run: dotnet test RoslynRunner.ApiTests/RoslynRunner.ApiTests.csproj --logger "console;verbosity=detailed"
+      - name: Run tests
+        run: dotnet test --logger "console;verbosity=detailed"
 
   publish:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -5,6 +5,8 @@ jobs:
     test:
         timeout-minutes: 60
         runs-on: ubuntu-latest
+        env:
+            RUN_PLAYWRIGHT_TESTS: "true"
         steps:
             - uses: actions/checkout@v4
             - name: Setup dotnet
@@ -18,5 +20,5 @@ jobs:
             - name: Build the legacy sample
               run: dotnet build
               working-directory: samples/LegacyWebApp
-            - name: Run your tests
-              run: dotnet test
+            - name: Run Playwright tests
+              run: dotnet test --filter "Category=Playwright"

--- a/RoslynRunner.EndToEndTests/RunnerContext.cs
+++ b/RoslynRunner.EndToEndTests/RunnerContext.cs
@@ -1,5 +1,7 @@
+using System;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Playwright;
+using NUnit.Framework;
 
 namespace RoslynRunner.EndToEndTests;
 
@@ -10,9 +12,20 @@ public class RunnerContext : RoslynRunner.ApiTests.AppContext
 
     public static IAPIRequestContext ApiRequestContext { get; private set; } = null!;
 
+    internal const string PlaywrightRunEnvironmentVariable = "RUN_PLAYWRIGHT_TESTS";
+
     [OneTimeSetUp]
     public override async Task Setup()
     {
+        var shouldRunPlaywrightTests = Environment.GetEnvironmentVariable(PlaywrightRunEnvironmentVariable);
+        var playwrightEnabled = string.Equals(shouldRunPlaywrightTests, "true", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(shouldRunPlaywrightTests, "1", StringComparison.OrdinalIgnoreCase);
+
+        if (!playwrightEnabled)
+        {
+            Assert.Ignore($"Playwright tests skipped. Set {PlaywrightRunEnvironmentVariable}=true to enable.");
+        }
+
         await base.Setup();
 
         var playwright = await Playwright.CreateAsync();

--- a/RoslynRunner.EndToEndTests/SampleRefactorTests.cs
+++ b/RoslynRunner.EndToEndTests/SampleRefactorTests.cs
@@ -1,17 +1,22 @@
-﻿using Microsoft.Playwright;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Playwright;
+using NUnit.Framework;
 using RoslynRunner.UI.Pages;
-using System.Net.Http;
+using RoslynRunner;
 
 namespace RoslynRunner.EndToEndTests;
 
 [NonParallelizable]
 [TestFixture]
+[Category("Playwright")]
 public class Tests : PageTest
 {
-    const int WaitTime = 30000;
+    private const int WaitTime = 30000;
 
     [Test]
-    [Ignore("selector timing out in CI")]
     public async Task UiCanRunSampleConversion()
     {
         await Page.GotoAsync(RunnerContext.BaseUrl);
@@ -51,11 +56,12 @@ public class Tests : PageTest
         var runs = await runResult.FromJson<List<RunParameters>>();
         Assert.That(runs?.Count, Is.AtLeast(1));
 
-        var run = runs.Last(r => r.RunCommand.ProcessorSolution == legacyWebAppConverterCsproj);
+        var run = runs!.Last(r => r.RunCommand.ProcessorSolution == legacyWebAppConverterCsproj);
         Assert.That(run.RunId, Is.Not.EqualTo(Guid.Empty));
         var runResponse = await RunnerContext.ApiRequestContext.GetAsync($"/runs/{run.RunId}");
         Assert.That(runResponse.Status, Is.EqualTo(200));
         var json = await runResponse.JsonAsync();
+        Assert.That(json, Is.Not.Null);
         Assert.That(File.Exists(targetFile), Is.True);
     }
 }


### PR DESCRIPTION
## Summary
- skip Playwright end-to-end tests unless the RUN_PLAYWRIGHT_TESTS environment variable is set
- tag the Playwright suite so it can be targeted explicitly and remove the unconditional ignore
- run the full test suite in the default CI workflow and configure the Playwright workflow to opt in and filter to the Playwright tests

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68ee9a956f58832fa7abf9d8dc882b29