### PR TITLE
Rename async-converted methods by default with opt-out

### DIFF
--- a/RoslynRunner.Utilities.InvocationTrees/AsyncConversion/AsyncConversionProcessor.cs
+++ b/RoslynRunner.Utilities.InvocationTrees/AsyncConversion/AsyncConversionProcessor.cs
@@ -55,7 +55,11 @@ public class AsyncConversionProcessor : ISolutionProcessor<AsyncConversionParame
         }
 
         var generator = new AsyncConversionGenerator(cache, solution);
-        var conversionResult = await generator.GenerateAsyncVersion(serviceType, context.MethodName, cancellationToken);
+        var conversionResult = await generator.GenerateAsyncVersion(
+            serviceType,
+            context.MethodName,
+            cancellationToken,
+            renameTransformedMethods: context.RenameTransformedMethods);
         if (conversionResult == null)
         {
             logger.LogInformation("no methods to convert");

--- a/RoslynRunner.Utilities.InvocationTrees/AsyncConversion/AsyncConversionProcessorParameters.cs
+++ b/RoslynRunner.Utilities.InvocationTrees/AsyncConversion/AsyncConversionProcessorParameters.cs
@@ -6,5 +6,6 @@ public record AsyncConversionParameters(
     string BranchName,
     string? MethodName = null,
     bool ReplaceExistingMethods = true,
+    bool RenameTransformedMethods = true,
     string? ChangeId = null,
     string? CommitMessage = null);

--- a/RoslynRunner/RoslynRunnerMcpTool.cs
+++ b/RoslynRunner/RoslynRunnerMcpTool.cs
@@ -179,6 +179,7 @@ public static class RoslynRunnerMcpTool
         [Description("The fully qualified name of the type to convert")] string typeName,
         [Description("The branch name that should contain the async changes")] string branchName,
         [Description("Optional starting method name")] string? methodName = null,
+        [Description("Set to false to keep the original method names when converting to async")] bool renameTransformedMethods = true,
         [Description("Optional commit message for the generated branch")] string? commitMessage = null,
         int maxTime = 300,
         CancellationToken cancellationToken = default)
@@ -194,6 +195,7 @@ public static class RoslynRunnerMcpTool
                 typeName,
                 branchName,
                 methodName,
+                RenameTransformedMethods: renameTransformedMethods,
                 ChangeId: null,
                 CommitMessage: commitMessage)));
 


### PR DESCRIPTION
## Summary
- rename converted async methods to include an Async suffix while updating call sites
- add a RenameTransformedMethods parameter to control suffixing from command tooling
- expand async conversion unit tests to cover renamed methods and the opt-out scenario

## Testing
- dotnet test Tests/RoslynRunner.AsyncConversion.UnitTests/RoslynRunner.AsyncConversion.UnitTests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68f055b6d240832f8609ed55fc4f2893