### PR TITLE
Align LegacyWebApp sample package versions

### DIFF
--- a/samples/LegacyWebApp/LegacyWebApp/LegacyWebApp.AppHost/LegacyWebApp.AppHost.csproj
+++ b/samples/LegacyWebApp/LegacyWebApp/LegacyWebApp.AppHost/LegacyWebApp.AppHost.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <Sdk Name="Aspire.AppHost.Sdk" Version="9.5.1" />
+    <Sdk Name="Aspire.AppHost.Sdk" Version="9.5.2" />
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <IsAspireHost>true</IsAspireHost>
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="9.1.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="9.5.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/LegacyWebApp/LegacyWebApp/LegacyWebApp.ServiceDefaults/LegacyWebApp.ServiceDefaults.csproj
+++ b/samples/LegacyWebApp/LegacyWebApp/LegacyWebApp.ServiceDefaults/LegacyWebApp.ServiceDefaults.csproj
@@ -6,15 +6,15 @@
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="9.5.1" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="9.5.2" />
 
-        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.3.0" />
-        <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.5.24201.12" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.7.0" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0" />
+        <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.5.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.13.1" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.13.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.13.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.13.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.13.0" />
     </ItemGroup>
 
 </Project>

--- a/samples/LegacyWebApp/LegacyWebAppConverter/LegacyWebAppConverter.csproj
+++ b/samples/LegacyWebApp/LegacyWebAppConverter/LegacyWebAppConverter.csproj
@@ -5,8 +5,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="9.5.1" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.13.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="9.5.2" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     </ItemGroup>
 </Project>

--- a/samples/LegacyWebApp/ModernApi.Analyzers/ModernApi.Analyzers.csproj
+++ b/samples/LegacyWebApp/ModernApi.Analyzers/ModernApi.Analyzers.csproj
@@ -18,10 +18,10 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.13.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />
-        <PackageReference Include="System.Collections.Immutable" Version="9.0.3" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+        <PackageReference Include="System.Collections.Immutable" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/LegacyWebApp/ModernWebApi/ModernWebApi.csproj
+++ b/samples/LegacyWebApp/ModernWebApi/ModernWebApi.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-    <PackageReference Include="Dapper" Version="2.1.38" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.5.2" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
+    <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- update the LegacyWebApp sample to the current Aspire Hosting packages
- align analyzer and tooling package references with the repository defaults
- refresh the ModernWebApi dependencies to the latest compatible releases

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6901279f8de8832f9d12fd47978b5bc1