### PR TITLE
Update async conversion to adjust interface signatures

### DIFF
--- a/Tests/RoslynRunner.AsyncConversion.UnitTests/AsyncConversionProcessorTests.cs
+++ b/Tests/RoslynRunner.AsyncConversion.UnitTests/AsyncConversionProcessorTests.cs
@@ -121,7 +121,7 @@ public class AsyncConversionProcessorTests
     }
 
     [Test]
-    public async Task GenerateAsyncVersion_DoesNotAddAsyncModifierToInterfaceMethods()
+    public async Task GenerateAsyncVersion_UpdatesInterfaceMethodsToAsyncSignatures()
     {
         const string source = @"namespace TestNamespace;
 
@@ -170,6 +170,9 @@ public class Dependency
             var interfaceMethod = interfaceDeclaration.Members.OfType<MethodDeclarationSyntax>().Single();
 
             Assert.That(interfaceMethod.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.AsyncKeyword)), Is.False);
+            Assert.That(interfaceMethod.Identifier.Text, Is.EqualTo("BarAsync"));
+            Assert.That(interfaceMethod.ReturnType.ToString(), Is.EqualTo("System.Threading.Tasks.Task"));
+            Assert.That(interfaceMethod.ParameterList.Parameters.Any(parameter => parameter.Identifier.Text == "cancellationToken"), Is.True);
 
             var classDeclaration = document.UpdatedRoot.DescendantNodes().OfType<ClassDeclarationSyntax>()
                 .Single(cls => cls.Identifier.Text == "Foo");


### PR DESCRIPTION
## Summary
- include implemented interface members when building the async conversion candidate list
- allow interface declarations to adopt Task-based signatures with cancellation tokens while skipping the async modifier
- expand the async conversion unit test to cover the updated interface expectations

## Testing
- MSBUILDTERMINALLOGGER=false dotnet test Tests/RoslynRunner.AsyncConversion.UnitTests/RoslynRunner.AsyncConversion.UnitTests.csproj

------
https://chatgpt.com/codex/tasks/task_e_690127785cc8832fb60f97f464fb669b