### PR TITLE
Use LibGit2Sharp for git operations and support separate change set commits

### DIFF
--- a/RoslynRunner.Git/RoslynChangeSet.cs
+++ b/RoslynRunner.Git/RoslynChangeSet.cs
@@ -53,7 +53,17 @@ public sealed class RoslynChangeSet
         AddTransformation(document, async (doc, ct) =>
         {
             var root = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
-            var newRoot = root!.ReplaceNode(originalMethod, annotatedReplacement);
+            var currentMethod = root!
+                .DescendantNodes()
+                .OfType<MethodDeclarationSyntax>()
+                .FirstOrDefault(m => m.IsEquivalentTo(originalMethod));
+
+            if (currentMethod is null)
+            {
+                return doc;
+            }
+
+            var newRoot = root.ReplaceNode(currentMethod, annotatedReplacement);
             return doc.WithSyntaxRoot(newRoot);
         });
     }
@@ -83,7 +93,16 @@ public sealed class RoslynChangeSet
         AddTransformation(document, async (doc, ct) =>
         {
             var root = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
-            var newRoot = root!.ReplaceNode(originalNode, annotatedReplacement);
+            var currentNode = root!
+                .DescendantNodesAndSelf()
+                .FirstOrDefault(node => node.IsEquivalentTo(originalNode));
+
+            if (currentNode is null)
+            {
+                return doc;
+            }
+
+            var newRoot = root.ReplaceNode(currentNode, annotatedReplacement);
             return doc.WithSyntaxRoot(newRoot);
         });
     }

--- a/RoslynRunner.Utilities.InvocationTrees/AsyncConversion/AsyncConversionProcessor.cs
+++ b/RoslynRunner.Utilities.InvocationTrees/AsyncConversion/AsyncConversionProcessor.cs
@@ -79,7 +79,7 @@ public class AsyncConversionProcessor : ISolutionProcessor<AsyncConversionParame
         var changeSet = roslynChanges.NewChangeSet(changeSetId, commitMessage);
         ApplyDocumentConversions(changeSet, conversionResult.Documents, solution, context.ReplaceExistingMethods);
 
-        await roslynChanges.ApplyAllAsync(context.BranchName, commitMessage, cancellationToken).ConfigureAwait(false);
+        await roslynChanges.ApplyAllAsync(context.BranchName, commitMessage, commitChangeSetsSeparately: false, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         RunContextAccessor.RunContext.Output.Add($"Updated branch '{context.BranchName}' with async conversions.");
     }


### PR DESCRIPTION
## Summary
- switch RoslynChanges to use LibGit2Sharp for branching, staging, committing, and diff generation
- add an option to ApplyAllAsync to commit each change set individually and update consumers
- harden syntax replacement to survive multiple passes and add a unit test for separate commits

## Testing
- dotnet test Tests/RoslynRunner.Git.UnitTests/RoslynRunner.Git.UnitTests.csproj --logger "console;verbosity=minimal"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694411de2b38832fb13310c54d4c021d)