### PR TITLE
Load assemblies from streams in TestAssemblyLoadContext

### DIFF
--- a/RoslynRunner.Core/TestAssemblyLoadContext.cs
+++ b/RoslynRunner.Core/TestAssemblyLoadContext.cs
@@ -49,7 +49,7 @@ public class TestAssemblyLoadContext : AssemblyLoadContext
             string assemblyPath = Path.Combine(_libDirectory, assemblyFileName);
             if (File.Exists(assemblyPath))
             {
-                localAssembly = LoadFromAssemblyPath(assemblyPath);
+                localAssembly = LoadFromPathIntoMemory(assemblyPath);
                 if (localAssembly != null)
                 {
                     return localAssembly;
@@ -62,7 +62,7 @@ public class TestAssemblyLoadContext : AssemblyLoadContext
             string? resolvedPath = _resolver.ResolveAssemblyToPath(name);
             if (resolvedPath != null)
             {
-                localAssembly = LoadFromAssemblyPath(resolvedPath);
+                localAssembly = LoadFromPathIntoMemory(resolvedPath);
                 if (localAssembly != null)
                 {
                     return localAssembly;
@@ -78,5 +78,21 @@ public class TestAssemblyLoadContext : AssemblyLoadContext
         
 
         return null;
+    }
+
+    private Assembly? LoadFromPathIntoMemory(string assemblyPath)
+    {
+        byte[] assemblyBytes = File.ReadAllBytes(assemblyPath);
+        using MemoryStream assemblyStream = new MemoryStream(assemblyBytes);
+
+        string pdbPath = Path.ChangeExtension(assemblyPath, ".pdb");
+        if (File.Exists(pdbPath))
+        {
+            byte[] pdbBytes = File.ReadAllBytes(pdbPath);
+            using MemoryStream pdbStream = new MemoryStream(pdbBytes);
+            return LoadFromStream(assemblyStream, pdbStream);
+        }
+
+        return LoadFromStream(assemblyStream, null);
     }
 }


### PR DESCRIPTION
## Summary
- load assemblies and optional PDBs into memory streams before loading
- use LoadFromStream so assemblies are loaded after file handles are released

## Testing
- dotnet test RoslynRunner.Core/RoslynRunner.Core.csproj --logger "console;verbosity=minimal"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69443c071bc0832f9b2315f87b78dfba)